### PR TITLE
Fix linear cache locking in CreateDeltaWatch function

### DIFF
--- a/pkg/cache/v2/linear.go
+++ b/pkg/cache/v2/linear.go
@@ -295,6 +295,8 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, st *stream.Str
 	value := make(chan DeltaResponse, 1)
 	systemVersion := cache.versionPrefix + strconv.FormatUint(cache.version, 10)
 
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
 	// if respondDelta returns nil this means that there is no change in any resource version from the previous snapshot
 	// create a new watch accordingly
 	if respondDelta(request, value, st, cache.resources, systemVersion, cache.log) == nil {
@@ -304,9 +306,7 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, st *stream.Str
 				cache.typeURL, st.ResourceVersions, systemVersion)
 		}
 
-		cache.mu.Lock()
 		cache.deltaWatches[watchID] = DeltaResponseWatch{Request: request, Response: value, StreamState: st}
-		cache.mu.Unlock()
 
 		return value, cache.cancelDeltaWatch(watchID)
 	}

--- a/pkg/cache/v2/linear.go
+++ b/pkg/cache/v2/linear.go
@@ -292,11 +292,11 @@ func (cache *LinearCache) CreateWatch(request *Request) (chan Response, func()) 
 }
 
 func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, st *stream.StreamState) (chan DeltaResponse, func()) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
 	value := make(chan DeltaResponse, 1)
 	systemVersion := cache.versionPrefix + strconv.FormatUint(cache.version, 10)
 
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
 	// if respondDelta returns nil this means that there is no change in any resource version from the previous snapshot
 	// create a new watch accordingly
 	if respondDelta(request, value, st, cache.resources, systemVersion, cache.log) == nil {

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -293,11 +293,11 @@ func (cache *LinearCache) CreateWatch(request *Request) (chan Response, func()) 
 }
 
 func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, st *stream.StreamState) (chan DeltaResponse, func()) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
 	value := make(chan DeltaResponse, 1)
 	systemVersion := cache.versionPrefix + strconv.FormatUint(cache.version, 10)
 
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
 	// if respondDelta returns nil this means that there is no change in any resource version from the previous snapshot
 	// create a new watch accordingly
 	if respondDelta(request, value, st, cache.resources, systemVersion, cache.log) == nil {

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -296,6 +296,8 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, st *stream.Str
 	value := make(chan DeltaResponse, 1)
 	systemVersion := cache.versionPrefix + strconv.FormatUint(cache.version, 10)
 
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
 	// if respondDelta returns nil this means that there is no change in any resource version from the previous snapshot
 	// create a new watch accordingly
 	if respondDelta(request, value, st, cache.resources, systemVersion, cache.log) == nil {
@@ -305,9 +307,7 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, st *stream.Str
 				cache.typeURL, st.ResourceVersions, systemVersion)
 		}
 
-		cache.mu.Lock()
 		cache.deltaWatches[watchID] = DeltaResponseWatch{Request: request, Response: value, StreamState: st}
-		cache.mu.Unlock()
 
 		return value, cache.cancelDeltaWatch(watchID)
 	}


### PR DESCRIPTION
Locking in this function is incorrect. We should also protect `cache.resources` and `cache.version` fields.